### PR TITLE
New 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
-# 📝 Idris v1.0
+# 📝 Idris v1.1
+
+<p align=center>
+
+![](resources/idrish/print.png)
 Idris é uma ferramenta para converter instruções em linguagem natural em scripts executáveis
+
+</p>
+
+## ✨ Recursos
+
+- **Tolerante a erros**, O Idris tolera um alto grau de erros de digitação sem que isso afete o resultado, por exemplo "pequizar" ainda será entendido como "pesquisar"
+- **Leveza**, Idris roda em condições extremas de recursos consumindo menos de 30 MB de RAM e funcionando em CPUs com 400 MHz
+- **Offline**, Idris está sempre disponível não depende de conexões com servidores externos
+- **Fácil de extender**, forneça um input e o comando que espera sair separado por tab no arquivo `database.tsv`
+- **Gratuito**, Idris é completamente gratuito você _não precisa_ pagar para usar
+- **Software Livre**, com uma licença permissiva (MIT) você pode modificar, extender e embutir o Idris sem se preocupar
+- **Ilimitado**, Como é 100% offline Idris não sofre com limites de uso
+- **Instantâneo**, mesmo com bases enormes Idris é capaz de fornecer os comandos instantaneamente
 
 ## 📥 Instalação
 Clone o repositório:
@@ -32,6 +49,7 @@ lua5.4 idris.lua --lang=<código do idioma> --database=<banco de dados com coman
 * `--shell-output`: Formata a saída para uso em scripts de shell.
 * `--interactive`: Entra no modo interativo.
 * `--compile`, `-c`: Gera um banco de dados `database.lua` a partir do arquivo `datasheet.tsv`.
+* `--update-idris-shell`, `-u`: Modifica o comportamento de `--compile` para atualizar o arquivo `idri-shell.lua`
 * `--verbose`, `-v`: Ativa a saída verbosa.
 * `--debug`, `-d`: Imprime a localização do banco de dados de cada comando.
 * `--help`, `-h`: Exibe a mensagem de ajuda.
@@ -40,7 +58,7 @@ lua5.4 idris.lua --lang=<código do idioma> --database=<banco de dados com coman
 
 #### Básico
 ```bash
-lua5.4 idris.lua 'crie um arquivo test.txt e insira a frase Hello World nele!'
+lua5.4 idris.lua --lang=pt_BR 'crie um arquivo test.txt e insira a frase Hello World nele!'
 ```
 
 #### Modo interativo
@@ -48,7 +66,7 @@ lua5.4 idris.lua 'crie um arquivo test.txt e insira a frase Hello World nele!'
 Para entrar no modo interativo, execute o comando nenhuma entrada:
 
 ```
-lua5.4 idris.lua --lang=pt_BR --database=demonstration
+lua5.4 idris.lua --lang=pt_BR --database=idris-shell
 ```
 
 # 🤝 Contribuição

--- a/idris.lua
+++ b/idris.lua
@@ -342,23 +342,29 @@ local function learn()
         currentStruct = currentStruct[token]
         if i == #tokens then
           currentStruct[0] = command:gsub("\n","\\n")
+          currentStruct[1] = tostring(row[3]):lower() == "true" and true or false
         end
       end
     end
   end
 
-  local printDB
   local dbString = "DB = {\n"
-  function printDB (struct,level)
-      local padding = ("  "):rep(level)
-      for key, value in pairs(struct) do
-          if type(value) ~= "string" then
-            dbString = dbString..(padding..'["'..key..'"] = {\n')
-            printDB(value,level+1)
-            dbString = dbString..(padding..'},\n')
-          else
-            dbString = dbString..(padding.."[0] = \""..value:gsub("\"","\\\"").."\",\n")
-          end
+  local function printDB (struct,level)
+      if type(struct) == "table" then
+        local padding = ("  "):rep(level)
+        for key, value in pairs(struct) do
+            if type(value) ~= "string" then
+              if type(key) == "number" then
+                dbString = dbString..(padding..'['..key..'] = '..tostring(value)..',\n')
+              else
+                dbString = dbString..(padding..'["'..key..'"] = {\n')
+                printDB(value,level+1)
+                dbString = dbString..(padding..'},\n')
+              end
+            else
+              dbString = dbString..(padding.."[0] = \""..value:gsub("\"","\\\"").."\",\n")
+            end
+        end
       end
   end
 

--- a/idris.lua
+++ b/idris.lua
@@ -34,6 +34,7 @@ local function printUsage()
   os.exit(0)
 end
 
+Language = {}
 local lang,database,prefix,separator,interactive,shellOutput,debugMode,updadeIdrish = nil,nil,"","\n",false,false,false,false
 
 local tokens,contexts,current_context = {},{},{}
@@ -108,7 +109,7 @@ local function printOutput(levels,base,args,contextPrinted)
         if debugMode then
           if contextPrinted == false then
             io.write("\n")
-            printContexts(0,contexts,_)
+            printContexts(0,contexts)
             io.write("------------------------------------------------------------------------\n\n")
             contextPrinted = true
           end

--- a/idris.lua
+++ b/idris.lua
@@ -200,10 +200,24 @@ local function processTokens()
           end
         end
 
+        local isPronoun = (Language.pronouns[token] or Language.pronouns[token:sub(1,-2)]) or false
+        if #current_context == 0 and isPronoun then
+          if current_context.struct[token] then
+            current_context[#current_context+1] = {
+              trigger = token,
+              struct = current_context.struct[token],
+              arg = "",
+              command = current_context.struct[token][0] or ""
+            }
+            current_context = current_context[#current_context]
+            token = nil
+          end
+        end
+
         if isPersonalPronoun and #current_context == 0 and #(contexts[#contexts-1] or {}) > 0 and contexts[#contexts] == current_context then
-          local testTigger = contexts[#contexts-1][1].trigger
-          if current_context.struct[testTigger] then
-            local struct = current_context.struct[testTigger]
+          local testTrigger = contexts[#contexts-1][1].trigger
+          if current_context.struct[testTrigger] then
+            local struct = current_context.struct[testTrigger]
             local arg = nil
             for j=#contexts-1, 1, -1 do
               if (contexts[j][1] or {}).arg ~= "" and (contexts[j][1] or {}).arg ~= nil then
@@ -212,7 +226,7 @@ local function processTokens()
             end
             if arg then
               current_context[#current_context+1] = {
-                trigger = testTigger,
+                trigger = testTrigger,
                 struct = struct,
                 arg = arg,
                 command = struct[0] or ""

--- a/idris.lua
+++ b/idris.lua
@@ -387,6 +387,8 @@ local function learn()
       if currentStruct == emptyTable then
         db[token] = db[token] or {}
         currentStruct = db[token]
+        currentStruct[0] = command:gsub("\n","\\n")
+        currentStruct[1] = tostring(row[3]):lower() == "true" and true or false
       else
         currentStruct[token] = currentStruct[token] or {}
         currentStruct = currentStruct[token]

--- a/idris.lua
+++ b/idris.lua
@@ -173,6 +173,16 @@ local function processTokens()
                   command = struct[0] or ""
                 }
                 current_context = current_context[#current_context]
+
+                if current_context.struct[1] then
+                  local command = current_context.command
+                  current_context = contexts[#contexts]
+                  current_context.command = command..separator..current_context.command
+                  for l=#current_context, 1, -1 do
+                    table.remove(current_context,l)
+                  end
+                end
+  
                 token = nil
                 break
               end
@@ -194,6 +204,16 @@ local function processTokens()
                 for n = j+1, #splited, 1 do
                   current_context.arg = current_context.arg..splited[n]..(n == #splited and "" or " ")
                 end
+
+                if current_context.struct[1] then
+                  local command = current_context.command
+                  current_context = contexts[#contexts]
+                  current_context.command = command..separator..current_context.command
+                  for j=#current_context, 1, -1 do
+                    table.remove(current_context,j)
+                  end
+                end
+  
                 contexts[#contexts].arg = ""
                 break
               end
@@ -201,7 +221,7 @@ local function processTokens()
           end
         end
 
-        local isPronoun = (Language.pronouns[token] or Language.pronouns[token:sub(1,-2)]) or false
+        local isPronoun = (Language.pronouns[(token or "")] or Language.pronouns[(token or ""):sub(1,-2)]) or false
         if #current_context == 0 and isPronoun then
           if current_context.struct[token] then
             current_context[#current_context+1] = {
@@ -211,6 +231,16 @@ local function processTokens()
               command = current_context.struct[token][0] or ""
             }
             current_context = current_context[#current_context]
+
+            if current_context.struct[1] then
+              local command = current_context.command
+              current_context = contexts[#contexts]
+              current_context.command = command..separator..current_context.command
+              for j=#current_context, 1, -1 do
+                table.remove(current_context,j)
+              end
+            end
+
             token = nil
           end
         end
@@ -233,6 +263,16 @@ local function processTokens()
                 command = struct[0] or ""
               }
               current_context = current_context[#current_context]
+
+              if current_context.struct[1] then
+                local command = current_context.command
+                current_context = contexts[#contexts]
+                current_context.command = command..separator..current_context.command
+                for j=#current_context, 1, -1 do
+                  table.remove(current_context,j)
+                end
+              end
+
               if current_context.struct[token] then
                 current_context[#current_context+1] = {
                   trigger = token,
@@ -256,6 +296,16 @@ local function processTokens()
             command = (struct or {[0] = ""})[0] or ""
           }
           current_context = current_context[#current_context]
+
+          if current_context.struct[1] then
+            local command = current_context.command
+            current_context = contexts[#contexts]
+            current_context.command = command..separator..current_context.command
+            for j=#current_context, 1, -1 do
+              table.remove(current_context,j)
+            end
+          end
+
           i = next_index or i
         else
           local arg = current_context.arg

--- a/languages/pt_BR.lua
+++ b/languages/pt_BR.lua
@@ -121,6 +121,10 @@ Language = {
         end
       end
       new_word = new_word:gsub("ce","sse"):gsub("ci","ssi"):gsub("de$","di"):gsub("te$","ti"):gsub("^h",""):gsub("k","c"):gsub("w","v"):gsub("oo","u")
+
+      for _, vogal in ipairs(vogals) do
+        new_word = new_word:gsub("r"..vogal.."s$","r"):gsub("z"..vogal.."z$",vogal)
+      end
       return new_word
     end
   ,


### PR DESCRIPTION
- **More spelling tolerance**, all words are now in singular form
- **More readable code**, it's now easier to implement features
- Allow personal pronouns as effective nouns, useful in Portuguese, this entry now works as expected:
  - `Me lembra da festa de aniversário de Ana as 7:00 PM`
- **Implementation of RFC 4180 in TSV**, so TSVs generated by Excel (UT8-Only) and LibreOffice Calc will work
- **Support for recursive commands**, it's now possible to generate compound commands in order while keeping `database.tsv` simple
- **Warnings fixed**, all warnings have been removed, so no "Global variable not defined" warnings will be displayed
- **Simple idris-shell update**, passing `-u` or `--update-idris-shell` will compile `database.tsv` into `idris-shell.lua`